### PR TITLE
update engines to support iojs and node >=0.12.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
     "supertest": "0.15.0"
   },
   "engines": {
-    "node": "0.11.*"
+    "node": ">= 0.12.0",
+    "iojs": ">= 1.0.0"
   },
   "dependencies": {
     "lodash.isregexp": "~2.4.1",


### PR DESCRIPTION
I have the following warning when installing `koa-slow` under `node@4.1.0`.
```shell
npm WARN engine koa-slow@0.1.1: wanted: {"node":"0.11.*"} (current: {"node":"4.1.0","npm":"3.3.4"})
```

Probably it makes sense to update `engines` field in `package.json` to the same values as in [koa](https://github.com/koajs/koa)